### PR TITLE
feat(history): add select-all and bulk deletion

### DIFF
--- a/app/src/components/History/HistoryTable.tsx
+++ b/app/src/components/History/HistoryTable.tsx
@@ -480,6 +480,8 @@ export function HistoryTable() {
   const hasMore = allHistory.length < total;
   const failedCount = history.filter((g) => g.status === 'failed').length;
   const hasBulkSelection = allGenerationsSelected || selectedGenerationIds.size > 0;
+  const everyGenerationSelected =
+    allGenerationsSelected && excludedGenerationIds.size === 0;
   const selectionSummary = allGenerationsSelected
     ? excludedGenerationIds.size > 0
       ? t('history.bulkSelection.allExcept', { count: excludedGenerationIds.size })
@@ -556,7 +558,7 @@ export function HistoryTable() {
             <div className="flex min-w-0 items-center gap-2">
               <Checkbox
                 id="select-all-generations"
-                checked={allGenerationsSelected}
+                checked={everyGenerationSelected}
                 onCheckedChange={handleSelectAllChange}
                 disabled={deleteGenerations.isPending}
                 aria-label={t('history.bulkSelection.selectAll')}
@@ -564,7 +566,7 @@ export function HistoryTable() {
               <button
                 type="button"
                 className="shrink-0 text-xs font-medium hover:text-accent"
-                onClick={() => handleSelectAllChange(!allGenerationsSelected)}
+                onClick={() => handleSelectAllChange(!everyGenerationSelected)}
                 disabled={deleteGenerations.isPending}
               >
                 {t('history.bulkSelection.selectAll')}
@@ -596,7 +598,9 @@ export function HistoryTable() {
                   disabled={clearFailed.isPending || deleteGenerations.isPending}
                 >
                   <Trash2 className="h-3 w-3" />
-                  {clearFailed.isPending ? 'Clearing...' : 'Clear failed'}
+                  {clearFailed.isPending
+                    ? t('history.clearFailedDialog.clearing')
+                    : t('history.clearFailedDialog.clearFailed')}
                 </Button>
               )}
               <Button

--- a/app/src/components/History/HistoryTable.tsx
+++ b/app/src/components/History/HistoryTable.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { AudioBars } from '@/components/AudioBars';
 import { EffectsChainEditor } from '@/components/Effects/EffectsChainEditor';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -48,6 +49,7 @@ import { BOTTOM_SAFE_AREA_PADDING } from '@/lib/constants/ui';
 import {
   useClearFailedGenerations,
   useDeleteGeneration,
+  useDeleteGenerations,
   useExportGeneration,
   useExportGenerationAudio,
   useHistory,
@@ -73,6 +75,14 @@ export function HistoryTable() {
   const [generationToDelete, setGenerationToDelete] = useState<{ id: string; name: string } | null>(
     null,
   );
+  const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const [selectedGenerationIds, setSelectedGenerationIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [allGenerationsSelected, setAllGenerationsSelected] = useState(false);
+  const [excludedGenerationIds, setExcludedGenerationIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [effectsDialogOpen, setEffectsDialogOpen] = useState(false);
   const [effectsTargetId, setEffectsTargetId] = useState<string | null>(null);
   const [effectsTargetVersions, setEffectsTargetVersions] = useState<GenerationVersionResponse[]>(
@@ -96,6 +106,7 @@ export function HistoryTable() {
   });
 
   const deleteGeneration = useDeleteGeneration();
+  const deleteGenerations = useDeleteGenerations();
   const clearFailed = useClearFailedGenerations();
   const [clearFailedDialogOpen, setClearFailedDialogOpen] = useState(false);
   const exportGeneration = useExportGeneration();
@@ -121,6 +132,7 @@ export function HistoryTable() {
   const addPendingGeneration = useGenerationStore((state) => state.addPendingGeneration);
   const setAudioWithAutoPlay = usePlayerStore((state) => state.setAudioWithAutoPlay);
   const restartCurrentAudio = usePlayerStore((state) => state.restartCurrentAudio);
+  const resetPlayer = usePlayerStore((state) => state.reset);
   const currentAudioId = usePlayerStore((state) => state.audioId);
   const isPlaying = usePlayerStore((state) => state.isPlaying);
   const audioUrl = usePlayerStore((state) => state.audioUrl);
@@ -148,11 +160,21 @@ export function HistoryTable() {
   const pendingCount = useGenerationStore((state) => state.pendingGenerationIds.size);
   const prevPendingCountRef = useRef(pendingCount);
   useEffect(() => {
-    if (deleteGeneration.isSuccess || importGeneration.isSuccess || clearFailed.isSuccess) {
+    if (
+      deleteGeneration.isSuccess ||
+      deleteGenerations.isSuccess ||
+      importGeneration.isSuccess ||
+      clearFailed.isSuccess
+    ) {
       setPage(0);
       setAllHistory([]);
     }
-  }, [deleteGeneration.isSuccess, importGeneration.isSuccess, clearFailed.isSuccess]);
+  }, [
+    deleteGeneration.isSuccess,
+    deleteGenerations.isSuccess,
+    importGeneration.isSuccess,
+    clearFailed.isSuccess,
+  ]);
 
   useEffect(() => {
     // A generation finished (pending count decreased) — scroll back to show it
@@ -251,10 +273,60 @@ export function HistoryTable() {
 
   const handleDeleteConfirm = () => {
     if (generationToDelete) {
-      deleteGeneration.mutate(generationToDelete.id);
+      const generationId = generationToDelete.id;
+      deleteGeneration.mutate(generationId, {
+        onSuccess: () => {
+          setSelectedGenerationIds((current) => {
+            const next = new Set(current);
+            next.delete(generationId);
+            return next;
+          });
+          setExcludedGenerationIds((current) => {
+            const next = new Set(current);
+            next.delete(generationId);
+            return next;
+          });
+          if (currentAudioId === generationId) resetPlayer();
+        },
+      });
       setDeleteDialogOpen(false);
       setGenerationToDelete(null);
     }
+  };
+
+  const clearBulkSelection = () => {
+    setAllGenerationsSelected(false);
+    setSelectedGenerationIds(new Set());
+    setExcludedGenerationIds(new Set());
+  };
+
+  const handleSelectAllChange = (checked: boolean) => {
+    if (checked) {
+      setAllGenerationsSelected(true);
+      setSelectedGenerationIds(new Set());
+      setExcludedGenerationIds(new Set());
+    } else {
+      clearBulkSelection();
+    }
+  };
+
+  const handleGenerationSelectionChange = (generationId: string, checked: boolean) => {
+    if (allGenerationsSelected) {
+      setExcludedGenerationIds((current) => {
+        const next = new Set(current);
+        if (checked) next.delete(generationId);
+        else next.add(generationId);
+        return next;
+      });
+      return;
+    }
+
+    setSelectedGenerationIds((current) => {
+      const next = new Set(current);
+      if (checked) next.add(generationId);
+      else next.delete(generationId);
+      return next;
+    });
   };
 
   const handleRetry = async (generationId: string) => {
@@ -407,6 +479,12 @@ export function HistoryTable() {
   const history = allHistory;
   const hasMore = allHistory.length < total;
   const failedCount = history.filter((g) => g.status === 'failed').length;
+  const hasBulkSelection = allGenerationsSelected || selectedGenerationIds.size > 0;
+  const selectionSummary = allGenerationsSelected
+    ? excludedGenerationIds.size > 0
+      ? t('history.bulkSelection.allExcept', { count: excludedGenerationIds.size })
+      : t('history.bulkSelection.allSelected')
+    : t('history.bulkSelection.selected', { count: selectedGenerationIds.size });
 
   const handleClearFailedConfirm = () => {
     clearFailed.mutate(undefined, {
@@ -428,6 +506,44 @@ export function HistoryTable() {
     });
   };
 
+  const handleBulkDeleteConfirm = () => {
+    const deletesCurrentAudio = currentAudioId
+      ? allGenerationsSelected
+        ? !excludedGenerationIds.has(currentAudioId)
+        : selectedGenerationIds.has(currentAudioId)
+      : false;
+
+    deleteGenerations.mutate(
+      allGenerationsSelected
+        ? {
+            delete_all: true,
+            excluded_ids: [...excludedGenerationIds],
+          }
+        : {
+            generation_ids: [...selectedGenerationIds],
+          },
+      {
+        onSuccess: (data) => {
+          if (deletesCurrentAudio) resetPlayer();
+          clearBulkSelection();
+          setBulkDeleteDialogOpen(false);
+          toast({
+            title: t('history.bulkDeleteDialog.successTitle'),
+            description: t('history.bulkDeleteDialog.successBody', { count: data.deleted }),
+          });
+        },
+        onError: (error) => {
+          setBulkDeleteDialogOpen(false);
+          toast({
+            title: t('history.bulkDeleteDialog.errorTitle'),
+            description: error instanceof Error ? error.message : t('common.error'),
+            variant: 'destructive',
+          });
+        },
+      },
+    );
+  };
+
   return (
     <div className="flex flex-col h-full min-h-0 relative">
       {history.length === 0 ? (
@@ -436,23 +552,69 @@ export function HistoryTable() {
         </div>
       ) : (
         <>
-          {failedCount > 0 && (
-            <div className="flex items-center justify-between px-1 pb-2">
-              <span className="text-xs text-muted-foreground">
-                {failedCount} failed {failedCount === 1 ? 'generation' : 'generations'}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 text-xs text-muted-foreground"
-                onClick={() => setClearFailedDialogOpen(true)}
-                disabled={clearFailed.isPending}
+          <div className="flex items-center justify-between gap-2 px-1 pb-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <Checkbox
+                id="select-all-generations"
+                checked={allGenerationsSelected}
+                onCheckedChange={handleSelectAllChange}
+                disabled={deleteGenerations.isPending}
+                aria-label={t('history.bulkSelection.selectAll')}
+              />
+              <button
+                type="button"
+                className="shrink-0 text-xs font-medium hover:text-accent"
+                onClick={() => handleSelectAllChange(!allGenerationsSelected)}
+                disabled={deleteGenerations.isPending}
               >
-                <Trash2 className="h-3 w-3 mr-1.5" />
-                {clearFailed.isPending ? 'Clearing...' : 'Clear failed'}
+                {t('history.bulkSelection.selectAll')}
+              </button>
+              {hasBulkSelection && (
+                <>
+                  <span className="truncate text-xs text-muted-foreground">
+                    {selectionSummary}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs text-muted-foreground"
+                    onClick={clearBulkSelection}
+                    disabled={deleteGenerations.isPending}
+                  >
+                    {t('history.bulkSelection.clear')}
+                  </Button>
+                </>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {failedCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs text-muted-foreground"
+                  onClick={() => setClearFailedDialogOpen(true)}
+                  disabled={clearFailed.isPending || deleteGenerations.isPending}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  {clearFailed.isPending ? 'Clearing...' : 'Clear failed'}
+                </Button>
+              )}
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-7 px-3 text-xs"
+                onClick={() => setBulkDeleteDialogOpen(true)}
+                disabled={!hasBulkSelection || deleteGenerations.isPending}
+              >
+                {deleteGenerations.isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3 w-3" />
+                )}
+                {t('history.bulkSelection.deleteSelected')}
               </Button>
             </div>
-          )}
+          </div>
           {isScrolled && (
             <div className="absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-background to-transparent z-10 pointer-events-none" />
           )}
@@ -469,6 +631,12 @@ export function HistoryTable() {
               const isGenerating = isInProgress;
               const isFailed = gen.status === 'failed';
               const isPlayable = !isGenerating && !isFailed;
+              const isSelectable = !isGenerating;
+              const isSelected = isSelectable
+                ? allGenerationsSelected
+                  ? !excludedGenerationIds.has(gen.id)
+                  : selectedGenerationIds.has(gen.id)
+                : false;
               const hasVersions = gen.versions && gen.versions.length > 1;
               const isVersionsExpanded = expandedVersionsId === gen.id;
               const isCancelling =
@@ -479,6 +647,7 @@ export function HistoryTable() {
                   className={cn(
                     'border rounded-md bg-card transition-colors text-left w-full',
                     isCurrentlyPlaying && 'bg-muted/70',
+                    isSelected && 'border-accent bg-accent/5',
                   )}
                 >
                   {/* Main row */}
@@ -502,7 +671,11 @@ export function HistoryTable() {
                     onMouseDown={(e) => {
                       if (!isPlayable) return;
                       const target = e.target as HTMLElement;
-                      if (target.closest('textarea') || window.getSelection()?.toString()) {
+                      if (
+                        target.closest('textarea') ||
+                        target.closest('[role="checkbox"]') ||
+                        window.getSelection()?.toString()
+                      ) {
                         return;
                       }
                       handlePlay(gen.id, gen.text, gen.profile_id);
@@ -517,8 +690,18 @@ export function HistoryTable() {
                       }
                     }}
                   >
-                    {/* Status icon */}
-                    <div className="flex items-center shrink-0 w-10 justify-center overflow-hidden">
+                    {/* Selection and status */}
+                    <div className="flex w-16 shrink-0 items-center justify-center gap-2 overflow-hidden">
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={(checked) =>
+                          handleGenerationSelectionChange(gen.id, checked)
+                        }
+                        disabled={!isSelectable || deleteGenerations.isPending}
+                        aria-label={t('history.bulkSelection.selectGeneration', {
+                          name: gen.profile_name,
+                        })}
+                      />
                       <AudioBars
                         mode={isGenerating ? 'generating' : isCurrentlyPlaying ? 'playing' : 'idle'}
                       />
@@ -796,6 +979,43 @@ export function HistoryTable() {
               disabled={deleteGeneration.isPending}
             >
               {deleteGeneration.isPending ? t('history.deleteDialog.deleting') : t('common.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('history.bulkDeleteDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {allGenerationsSelected
+                ? excludedGenerationIds.size > 0
+                  ? t('history.bulkDeleteDialog.bodyAllExcept', {
+                      count: excludedGenerationIds.size,
+                    })
+                  : t('history.bulkDeleteDialog.bodyAll')
+                : t('history.bulkDeleteDialog.bodySelected', {
+                    count: selectedGenerationIds.size,
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBulkDeleteDialogOpen(false)}
+              disabled={deleteGenerations.isPending}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleBulkDeleteConfirm}
+              disabled={deleteGenerations.isPending}
+            >
+              {deleteGenerations.isPending
+                ? t('history.bulkDeleteDialog.deleting')
+                : t('history.bulkSelection.deleteSelected')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/src/components/ui/checkbox.tsx
+++ b/app/src/components/ui/checkbox.tsx
@@ -3,7 +3,10 @@ import * as React from 'react';
 import { cn } from '@/lib/utils/cn';
 
 export interface CheckboxProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  extends Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    'aria-checked' | 'onChange' | 'onClick' | 'role' | 'type'
+  > {
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
 }
@@ -12,6 +15,7 @@ const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
   ({ checked = false, onCheckedChange, disabled = false, className, id, ...props }, ref) => {
     return (
       <button
+        {...props}
         type="button"
         ref={ref}
         id={id}
@@ -30,7 +34,6 @@ const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
           !disabled && 'cursor-pointer',
           className,
         )}
-        {...props}
       >
         {checked && <Check className="h-3 w-3 text-accent-foreground" />}
       </button>

--- a/app/src/components/ui/checkbox.tsx
+++ b/app/src/components/ui/checkbox.tsx
@@ -2,12 +2,10 @@ import { Check } from 'lucide-react';
 import * as React from 'react';
 import { cn } from '@/lib/utils/cn';
 
-export interface CheckboxProps {
+export interface CheckboxProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
-  disabled?: boolean;
-  className?: string;
-  id?: string;
 }
 
 const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -688,6 +688,7 @@
       "body_one": "This will permanently delete {{count}} failed generation from your history. This cannot be undone.",
       "body_other": "This will permanently delete {{count}} failed generations from your history. This cannot be undone.",
       "clearing": "Clearing…",
+      "clearFailed": "Clear failed",
       "clearAll": "Clear all"
     },
     "importDialog": {

--- a/app/src/i18n/locales/en/translation.json
+++ b/app/src/i18n/locales/en/translation.json
@@ -654,6 +654,30 @@
       "applyEffects": "Apply Effects",
       "regenerate": "Regenerate"
     },
+    "bulkSelection": {
+      "selectAll": "Select all",
+      "selectGeneration": "Select generation from {{name}}",
+      "clear": "Clear",
+      "selected_one": "{{count}} selected",
+      "selected_other": "{{count}} selected",
+      "allSelected": "All generations selected",
+      "allExcept_one": "All except {{count}} selected",
+      "allExcept_other": "All except {{count}} selected",
+      "deleteSelected": "Delete selected"
+    },
+    "bulkDeleteDialog": {
+      "title": "Delete selected generations?",
+      "bodySelected_one": "This will permanently delete the selected generation and its audio. This action cannot be undone.",
+      "bodySelected_other": "This will permanently delete {{count}} selected generations and their audio. This action cannot be undone.",
+      "bodyAll": "This will permanently delete all completed and failed generations. Active generations will be kept. This action cannot be undone.",
+      "bodyAllExcept_one": "This will permanently delete all completed and failed generations except the one you deselected. Active generations will be kept. This action cannot be undone.",
+      "bodyAllExcept_other": "This will permanently delete all completed and failed generations except the {{count}} you deselected. Active generations will be kept. This action cannot be undone.",
+      "deleting": "Deleting…",
+      "successTitle": "Generations deleted",
+      "successBody_one": "{{count}} generation was deleted.",
+      "successBody_other": "{{count}} generations were deleted.",
+      "errorTitle": "Bulk deletion failed"
+    },
     "deleteDialog": {
       "title": "Delete Generation",
       "body": "Are you sure you want to delete this generation from \"{{name}}\"? This action cannot be undone.",

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -320,6 +320,17 @@ class ApiClient {
     });
   }
 
+  async deleteGenerations(request: {
+    generation_ids?: string[];
+    delete_all?: boolean;
+    excluded_ids?: string[];
+  }): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>('/history/bulk-delete', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
   async clearFailedGenerations(): Promise<{ deleted: number }> {
     return this.request<{ deleted: number }>(`/history/failed`, {
       method: 'DELETE',

--- a/app/src/lib/hooks/useHistory.ts
+++ b/app/src/lib/hooks/useHistory.ts
@@ -29,6 +29,21 @@ export function useDeleteGeneration() {
   });
 }
 
+export function useDeleteGenerations() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: {
+      generation_ids?: string[];
+      delete_all?: boolean;
+      excluded_ids?: string[];
+    }) => apiClient.deleteGenerations(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
+  });
+}
+
 export function useClearFailedGenerations() {
   const queryClient = useQueryClient();
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -139,6 +139,14 @@ class HistoryQuery(BaseModel):
     offset: int = Field(default=0, ge=0)
 
 
+class HistoryBulkDeleteRequest(BaseModel):
+    """Delete selected generations or every inactive history entry."""
+
+    generation_ids: List[str] = Field(default_factory=list, max_length=5000)
+    delete_all: bool = False
+    excluded_ids: List[str] = Field(default_factory=list, max_length=5000)
+
+
 class HistoryResponse(BaseModel):
     """Response model for history entry (includes profile name)."""
 

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -69,6 +69,24 @@ async def clear_failed_generations(db: Session = Depends(get_db)):
     return {"deleted": count}
 
 
+@router.post("/history/bulk-delete")
+async def bulk_delete_generations(
+    request: models.HistoryBulkDeleteRequest,
+    db: Session = Depends(get_db),
+):
+    """Delete selected history entries, or all inactive entries except exclusions."""
+    if not request.delete_all and not request.generation_ids:
+        raise HTTPException(status_code=400, detail="Select at least one generation to delete")
+
+    count = await history.delete_generations(
+        db,
+        generation_ids=request.generation_ids,
+        delete_all=request.delete_all,
+        excluded_ids=request.excluded_ids,
+    )
+    return {"deleted": count}
+
+
 @router.get("/history/{generation_id}", response_model=models.HistoryResponse)
 async def get_generation(
     generation_id: str,

--- a/backend/routes/history.py
+++ b/backend/routes/history.py
@@ -75,8 +75,20 @@ async def bulk_delete_generations(
     db: Session = Depends(get_db),
 ):
     """Delete selected history entries, or all inactive entries except exclusions."""
-    if not request.delete_all and not request.generation_ids:
-        raise HTTPException(status_code=400, detail="Select at least one generation to delete")
+    if request.delete_all:
+        if request.generation_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="generation_ids cannot be combined with delete_all",
+            )
+    else:
+        if request.excluded_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="excluded_ids requires delete_all",
+            )
+        if not request.generation_ids:
+            raise HTTPException(status_code=400, detail="Select at least one generation to delete")
 
     count = await history.delete_generations(
         db,

--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -270,6 +270,51 @@ async def delete_generation(
     return True
 
 
+async def delete_generations(
+    db: Session,
+    *,
+    generation_ids: List[str] | None = None,
+    delete_all: bool = False,
+    excluded_ids: List[str] | None = None,
+) -> int:
+    """Bulk-delete history while preserving active synthesis jobs."""
+    from . import versions as versions_mod
+
+    active_statuses = ("loading_model", "generating")
+    query = db.query(DBGeneration).filter(
+        or_(DBGeneration.status.is_(None), ~DBGeneration.status.in_(active_statuses))
+    )
+
+    if delete_all:
+        exclusions = set(excluded_ids or [])
+        if exclusions:
+            query = query.filter(~DBGeneration.id.in_(exclusions))
+    else:
+        selected_ids = set(generation_ids or [])
+        if not selected_ids:
+            return 0
+        query = query.filter(DBGeneration.id.in_(selected_ids))
+
+    generations = query.all()
+    for generation in generations:
+        versions_mod.delete_versions_for_generation(generation.id, db)
+
+        if generation.audio_path:
+            audio_path = config.resolve_storage_path(generation.audio_path)
+            if audio_path is not None and audio_path.exists():
+                try:
+                    audio_path.unlink()
+                except OSError:
+                    # Match failed-history cleanup: a locked file should not
+                    # prevent the remaining selected rows from being removed.
+                    pass
+
+        db.delete(generation)
+
+    db.commit()
+    return len(generations)
+
+
 async def delete_failed_generations(db: Session) -> int:
     """
     Delete every generation whose status is 'failed'.

--- a/backend/services/history.py
+++ b/backend/services/history.py
@@ -286,16 +286,23 @@ async def delete_generations(
     )
 
     if delete_all:
+        # Filter exclusions in Python so a large history does not exceed
+        # SQLite's bound-variable limit.
         exclusions = set(excluded_ids or [])
-        if exclusions:
-            query = query.filter(~DBGeneration.id.in_(exclusions))
+        generations = [
+            generation for generation in query.all() if generation.id not in exclusions
+        ]
     else:
-        selected_ids = set(generation_ids or [])
+        selected_ids = list(set(generation_ids or []))
         if not selected_ids:
             return 0
-        query = query.filter(DBGeneration.id.in_(selected_ids))
 
-    generations = query.all()
+        # SQLite builds one bound variable per ID. Keep each query safely
+        # below the common 999-variable limit.
+        generations = []
+        for start in range(0, len(selected_ids), 500):
+            chunk = selected_ids[start : start + 500]
+            generations.extend(query.filter(DBGeneration.id.in_(chunk)).all())
     for generation in generations:
         versions_mod.delete_versions_for_generation(generation.id, db)
 

--- a/backend/tests/test_history_bulk_delete.py
+++ b/backend/tests/test_history_bulk_delete.py
@@ -90,5 +90,59 @@ async def test_bulk_delete_removes_selected_files_and_preserves_active_jobs(
     assert session.get(Generation, "excluded") is not None
     assert not all_audio.exists()
 
+    many_ids = [f"bulk-{index}" for index in range(1200)]
+    session.add_all(
+        [
+            Generation(
+                id=generation_id,
+                profile_id=profile.id,
+                text=generation_id,
+                status="completed",
+            )
+            for generation_id in many_ids
+        ]
+    )
+    session.commit()
+
+    deleted = await delete_generations(session, generation_ids=many_ids)
+
+    assert deleted == len(many_ids)
+    assert (
+        session.query(Generation).filter(Generation.id.in_(many_ids[:500])).count()
+        == 0
+    )
+
+    many_exclusions = [f"excluded-{index}" for index in range(1200)]
+    session.add_all(
+        [
+            Generation(
+                id=generation_id,
+                profile_id=profile.id,
+                text=generation_id,
+                status="failed",
+            )
+            for generation_id in many_exclusions
+        ]
+        + [
+            Generation(
+                id="delete-all-target",
+                profile_id=profile.id,
+                text="delete all target",
+                status="completed",
+            )
+        ]
+    )
+    session.commit()
+
+    deleted = await delete_generations(
+        session,
+        delete_all=True,
+        excluded_ids=["excluded", *many_exclusions],
+    )
+
+    assert deleted == 1
+    assert session.get(Generation, "delete-all-target") is None
+    assert session.get(Generation, many_exclusions[-1]) is not None
+
     session.close()
     engine.dispose()

--- a/backend/tests/test_history_bulk_delete.py
+++ b/backend/tests/test_history_bulk_delete.py
@@ -1,0 +1,94 @@
+"""Regression tests for generation-history bulk deletion."""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend import config
+from backend.database import Base, Generation, VoiceProfile
+from backend.services.history import delete_generations
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_removes_selected_files_and_preserves_active_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    monkeypatch.setattr(
+        config,
+        "resolve_storage_path",
+        lambda value: Path(value) if value else None,
+    )
+
+    profile = VoiceProfile(id="profile", name="Test voice", language="ar")
+    selected_audio = tmp_path / "selected.wav"
+    all_audio = tmp_path / "all.wav"
+    selected_audio.write_bytes(b"selected")
+    all_audio.write_bytes(b"all")
+    session.add_all(
+        [
+            profile,
+            Generation(
+                id="selected",
+                profile_id=profile.id,
+                text="selected",
+                status="completed",
+                audio_path=str(selected_audio),
+            ),
+            Generation(
+                id="active",
+                profile_id=profile.id,
+                text="active",
+                status="generating",
+            ),
+            Generation(
+                id="excluded",
+                profile_id=profile.id,
+                text="excluded",
+                status="failed",
+            ),
+            Generation(
+                id="all",
+                profile_id=profile.id,
+                text="all",
+                status="completed",
+                audio_path=str(all_audio),
+            ),
+        ]
+    )
+    session.commit()
+
+    deleted = await delete_generations(
+        session,
+        generation_ids=["selected", "active"],
+    )
+
+    assert deleted == 1
+    assert session.get(Generation, "selected") is None
+    assert session.get(Generation, "active") is not None
+    assert not selected_audio.exists()
+
+    deleted = await delete_generations(
+        session,
+        delete_all=True,
+        excluded_ids=["excluded"],
+    )
+
+    assert deleted == 1
+    assert session.get(Generation, "all") is None
+    assert session.get(Generation, "active") is not None
+    assert session.get(Generation, "excluded") is not None
+    assert not all_audio.exists()
+
+    session.close()
+    engine.dispose()


### PR DESCRIPTION
## Summary
- add per-generation selection and a server-wide Select all mode for history clips
- add a confirmation flow and clear selection controls
- delete audio/version files in bulk while preserving active synthesis jobs
- reset the player if its current clip is deleted

## Validation
- 24 focused backend tests passed (bulk deletion, F5-TTS, TADA alignment, CUDA selection)
- app and web TypeScript checks passed in Docker
- production Docker container is healthy with CUDA available
- empty bulk-delete requests return HTTP 400 without changing history