### PR TITLE
fix(gpu): download CUDA/ROCm backends from this fork's releases

### DIFF
--- a/backend/services/cuda.py
+++ b/backend/services/cuda.py
@@ -27,7 +27,7 @@ from ..utils.progress import get_progress_manager
 
 logger = logging.getLogger(__name__)
 
-GITHUB_RELEASES_URL = "https://github.com/jamiepine/voicebox/releases/download"
+GITHUB_RELEASES_URL = "https://github.com/samykabu/voicebox/releases/download"
 
 PROGRESS_KEY = "cuda-backend"
 

--- a/backend/services/rocm.py
+++ b/backend/services/rocm.py
@@ -28,7 +28,7 @@ from .. import __version__
 
 logger = logging.getLogger(__name__)
 
-GITHUB_RELEASES_URL = "https://github.com/jamiepine/voicebox/releases/download"
+GITHUB_RELEASES_URL = "https://github.com/samykabu/voicebox/releases/download"
 
 PROGRESS_KEY = "rocm-backend"
 

--- a/backend/tests/test_rocm_download.py
+++ b/backend/tests/test_rocm_download.py
@@ -137,18 +137,18 @@ async def test_download_rocm_binary_progress_reporting(mock_backends_dir, fake_t
     libs_sha = hashlib.sha256(fake_tar_gz).hexdigest()
 
     responses = {
-        "https://github.com/jamiepine/voicebox/releases/download/v0.2.3/voicebox-server-rocm.tar.gz": FakeResponse(
+        "https://github.com/samykabu/voicebox/releases/download/v0.2.3/voicebox-server-rocm.tar.gz": FakeResponse(
             content=fake_tar_gz,
             headers={"content-length": str(len(fake_tar_gz))},
         ),
-        "https://github.com/jamiepine/voicebox/releases/download/v0.2.3/voicebox-server-rocm.tar.gz.sha256": FakeResponse(
+        "https://github.com/samykabu/voicebox/releases/download/v0.2.3/voicebox-server-rocm.tar.gz.sha256": FakeResponse(
             content=f"{server_sha}  voicebox-server-rocm.tar.gz\n".encode(),
         ),
-        f"https://github.com/jamiepine/voicebox/releases/download/v0.2.3/rocm-libs-{rocm.ROCM_LIBS_VERSION}.tar.gz": FakeResponse(
+        f"https://github.com/samykabu/voicebox/releases/download/v0.2.3/rocm-libs-{rocm.ROCM_LIBS_VERSION}.tar.gz": FakeResponse(
             content=fake_tar_gz,
             headers={"content-length": str(len(fake_tar_gz))},
         ),
-        f"https://github.com/jamiepine/voicebox/releases/download/v0.2.3/rocm-libs-{rocm.ROCM_LIBS_VERSION}.tar.gz.sha256": FakeResponse(
+        f"https://github.com/samykabu/voicebox/releases/download/v0.2.3/rocm-libs-{rocm.ROCM_LIBS_VERSION}.tar.gz.sha256": FakeResponse(
             content=f"{libs_sha}  rocm-libs.tar.gz\n".encode(),
         ),
     }


### PR DESCRIPTION
## Summary
- The app requests `voicebox-server-cuda.tar.gz` / ROCm archives for its own version tag from `jamiepine/voicebox`, where the fork's tags do not exist, so the GPU tab download fails with a 404 on the checksum.
- Point `GITHUB_RELEASES_URL` in `services/cuda.py` and `services/rocm.py` at `samykabu/voicebox` and update the ROCm download test fixtures.

This commit was pushed to the branch a few seconds after PR #6 was merged, so it missed that merge.

## Verification
- `test_rocm_download.py` and `test_cuda_device_selection.py` pass (7 tests).
- `https://github.com/samykabu/voicebox/releases/download/v0.5.2/voicebox-server-cuda.tar.gz.sha256` returns HTTP 200 now that v0.5.2 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)