### PR TITLE
chore: point release, license and clone links at this fork

### DIFF
--- a/.agents/skills/release-bump/SKILL.md
+++ b/.agents/skills/release-bump/SKILL.md
@@ -53,8 +53,8 @@ Finalize the changelog draft, bump the version across all tracked files, and cre
    - Add a new link for the new version
 
    ```markdown
-   [Unreleased]: https://github.com/jamiepine/voicebox/compare/vX.Y.Z...HEAD
-   [X.Y.Z]: https://github.com/jamiepine/voicebox/compare/vPREVIOUS...vX.Y.Z
+   [Unreleased]: https://github.com/samykabu/voicebox/compare/vX.Y.Z...HEAD
+   [X.Y.Z]: https://github.com/samykabu/voicebox/compare/vPREVIOUS...vX.Y.Z
    ```
 
 4. **Stage the changelog.**

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/jamiepine/voicebox/releases">
-    <img src="https://img.shields.io/github/downloads/jamiepine/voicebox/total?style=flat&color=blue" alt="Downloads" />
+  <a href="https://github.com/samykabu/voicebox/releases">
+    <img src="https://img.shields.io/github/downloads/samykabu/voicebox/total?style=flat&color=blue" alt="Downloads" />
   </a>
-  <a href="https://github.com/jamiepine/voicebox/releases/latest">
-    <img src="https://img.shields.io/github/v/release/jamiepine/voicebox?style=flat" alt="Release" />
+  <a href="https://github.com/samykabu/voicebox/releases/latest">
+    <img src="https://img.shields.io/github/v/release/samykabu/voicebox?style=flat" alt="Release" />
   </a>
-  <a href="https://github.com/jamiepine/voicebox/stargazers">
-    <img src="https://img.shields.io/github/stars/jamiepine/voicebox?style=flat" alt="Stars" />
+  <a href="https://github.com/samykabu/voicebox/stargazers">
+    <img src="https://img.shields.io/github/stars/samykabu/voicebox?style=flat" alt="Stars" />
   </a>
-  <a href="https://github.com/jamiepine/voicebox/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/jamiepine/voicebox?style=flat" alt="License" />
+  <a href="https://github.com/samykabu/voicebox/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/samykabu/voicebox?style=flat" alt="License" />
   </a>
   <a href="https://deepwiki.com/jamiepine/voicebox">
     <img src="https://img.shields.io/static/v1?label=Ask&message=DeepWiki&color=5B6EF7" alt="Ask DeepWiki" />
@@ -94,7 +94,7 @@ The two cloud incumbents sit on opposite halves of the voice I/O loop — Eleven
 | --------------------- | ------------------------------------------------------ |
 | macOS (Apple Silicon) | [Download DMG](https://voicebox.sh/download/mac-arm)   |
 | macOS (Intel)         | [Download DMG](https://voicebox.sh/download/mac-intel) |
-| Windows               | [Download MSI](https://voicebox.sh/download/windows)   |
+| Windows               | [Download MSI](https://github.com/samykabu/voicebox/releases/latest)   |
 | Docker                | `docker compose up`                                    |
 
 > **Arabic F5-TTS / Habibi on NVIDIA:** use
@@ -103,7 +103,7 @@ The two cloud incumbents sit on opposite halves of the voice I/O loop — Eleven
 > CUDA libraries, models, and FFmpeg off the host. See the
 > [Arabic CUDA deployment guide](docs/content/docs/overview/docker-arabic-f5-habibi.mdx).
 
-> **[View all binaries →](https://github.com/jamiepine/voicebox/releases/latest)**
+> **[View all binaries →](https://github.com/samykabu/voicebox/releases/latest)**
 
 > **Linux** — Pre-built binaries are not yet available. See [voicebox.sh/linux-install](https://voicebox.sh/linux-install) for build-from-source instructions.
 
@@ -414,7 +414,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup and contribution guide
 ### Quick Start
 
 ```bash
-git clone https://github.com/jamiepine/voicebox.git
+git clone https://github.com/samykabu/voicebox.git
 cd voicebox
 
 just setup   # creates Python venv, installs all deps

--- a/app/src/components/ServerTab/AboutPage.tsx
+++ b/app/src/components/ServerTab/AboutPage.tsx
@@ -97,7 +97,7 @@ export function AboutPage() {
                 <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-muted-foreground transition-colors" />
               </a>
               <a
-                href="https://github.com/jamiepine/voicebox"
+                href="https://github.com/samykabu/voicebox"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group inline-flex items-center gap-2 rounded-lg border border-border/60 px-4 py-2 text-sm transition-colors hover:bg-muted/50"
@@ -124,7 +124,7 @@ export function AboutPage() {
                   link: (
                     // biome-ignore lint/a11y/useAnchorContent: Trans fills content at runtime
                     <a
-                      href="https://github.com/jamiepine/voicebox/blob/main/LICENSE"
+                      href="https://github.com/samykabu/voicebox/blob/main/LICENSE"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="hover:text-muted-foreground/60 transition-colors"


### PR DESCRIPTION
## Summary
Follow-up to the CUDA/ROCm download fix (#7). Audit of every upstream-hosted reference reachable from the app, README and release tooling:

**Repointed to samykabu/voicebox (resource verified present on the fork):**
- About page: source repo link and LICENSE link.
- README: release badges/links, stargazers, LICENSE, "View all binaries", `git clone` URL, Windows download row (now the fork's latest release page).
- release-bump skill: changelog compare-link templates.

**Left unchanged (not hosted on the fork):**
- voicebox.sh / api.voicebox.sh / docs.voicebox.sh (upstream cloud and docs), HuggingFace model repos, deepwiki, trendshift, macOS DMG download rows, author credit and Buy Me a Coffee links.

Runtime download URLs (updater, CUDA, ROCm) were already fixed in v0.5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)