### PR TITLE
fix(app): restart a stale server left running across an upgrade

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,10 +8,11 @@ import { useAutoUpdater } from '@/hooks/useAutoUpdater';
 import { useThemeSync } from '@/hooks/useThemeSync';
 import { apiClient } from '@/lib/api/client';
 import type { HealthResponse } from '@/lib/api/types';
-import { useChordSync } from '@/lib/hooks/useChordSync';
 import { TOP_SAFE_AREA_PADDING } from '@/lib/constants/ui';
+import { useChordSync } from '@/lib/hooks/useChordSync';
 import { cn } from '@/lib/utils/cn';
 import { usePlatform } from '@/platform/PlatformContext';
+import type { Platform } from '@/platform/types';
 import { router } from '@/router';
 import { useLogStore } from '@/stores/logStore';
 import {
@@ -50,6 +51,25 @@ function isPortInUseError(error: unknown): boolean {
     msg.includes('EADDRINUSE') ||
     msg.includes('address already in use')
   );
+}
+
+/**
+ * A server left running across an app upgrade (keep-server-running) still
+ * answers on the port, so start_server reuses it and the UI talks to old
+ * backend code. Restart it when its version does not match the app.
+ */
+async function restartIfStaleServer(platform: Platform): Promise<void> {
+  try {
+    const [health, appVersion] = await Promise.all([
+      apiClient.getHealth(),
+      platform.metadata.getVersion(),
+    ]);
+    if (!health.version || health.version === appVersion) return;
+    console.warn(`Server ${health.version} does not match app ${appVersion}, restarting server...`);
+    await platform.lifecycle.restartServer();
+  } catch (error) {
+    console.error('Stale server check failed:', error);
+  }
 }
 
 const LOADING_MESSAGES = [
@@ -171,10 +191,13 @@ function MainApp() {
 
     platform.lifecycle
       .startServer(isRemote, customModelsDir)
-      .then((serverUrl) => {
+      .then(async (serverUrl) => {
         console.log('Server is ready at:', serverUrl);
         // Update the server URL in the store with the dynamically assigned port
         useServerStore.getState().setServerUrl(serverUrl);
+        if (!isRemote) {
+          await restartIfStaleServer(platform);
+        }
         setServerReady(true);
         // Mark that we started the server (so we know to stop it on close)
         window.__voiceboxServerStartedByApp = true;

--- a/app/src/lib/api/types.ts
+++ b/app/src/lib/api/types.ts
@@ -1,6 +1,7 @@
 // API Types matching backend Pydantic models
-import type { LanguageCode } from '@/lib/constants/languages';
+
 import type { HabibiModelId } from '@/lib/constants/habibiModels';
+import type { LanguageCode } from '@/lib/constants/languages';
 
 export type VoiceType = 'cloned' | 'preset' | 'designed';
 
@@ -264,6 +265,7 @@ export interface TranscriptionResponse {
 
 export interface HealthResponse {
   status: string;
+  version?: string;
   model_loaded: boolean;
   model_downloaded?: boolean;
   model_size?: string;

--- a/backend/models.py
+++ b/backend/models.py
@@ -446,6 +446,7 @@ class HealthResponse(BaseModel):
     """Response model for health check."""
 
     status: str
+    version: Optional[str] = None  # Server version, lets the app detect a stale sidecar
     model_loaded: bool
     model_downloaded: Optional[bool] = None  # Whether model is cached/downloaded
     model_size: Optional[str] = None  # Current model size if loaded

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from .. import config, models
+from .. import __version__, config, models
 from ..services import tts
 from ..database import get_db
 from ..utils.platform_detect import get_backend_type, is_amd_gpu_windows
@@ -178,6 +178,7 @@ async def health():
 
     return models.HealthResponse(
         status="healthy",
+        version=__version__,
         model_loaded=model_loaded,
         model_downloaded=model_downloaded,
         model_size=model_size,


### PR DESCRIPTION
## Problem
After upgrading 0.5.2 → 0.5.3 the GPU tab still failed with the upstream v0.5.2 CUDA URL. The UI showed v0.5.3 but the backend answering was the old sidecar: with "keep server running on close" enabled the 0.5.2 server survives the MSI upgrade, and `start_server` (main.rs) reuses any Voicebox server already on port 17493.

## Fix
- `/health` now includes `version` (backend `__version__`).
- On production startup (local mode), `App.tsx` compares `health.version` with the Tauri app version and calls `restartServer()` when they differ. `stop_server` already shuts down a reused server via its recorded PID / `/shutdown`, so no Rust change is needed.

## Caveat
A 0.5.2 server does not report `version`, so this guard only protects upgrades from 0.5.4 onward. For the current stale 0.5.2 server: end the `voicebox-server` process (or reboot) and relaunch Voicebox once.

## Verification
- `bun run typecheck` passes; biome clean.
- Backend: ruff clean, `HealthResponse.version` round-trips `__version__`, middleware/CORS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)