### PR TITLE
fix(models): copy HF cache files when symlinks cannot be read

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -355,10 +355,51 @@ async def _run_startup(application: FastAPI) -> None:
         cache_dir = Path(hf_constants.HF_HUB_CACHE)
         cache_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Model cache: %s", cache_dir)
+        disable_hf_symlinks_if_unreadable(cache_dir)
     except Exception as e:
         logger.warning("Could not create HuggingFace cache directory: %s", e)
 
     logger.info("Ready")
+
+
+def disable_hf_symlinks_if_unreadable(cache_dir: Path) -> bool:
+    """Make huggingface_hub copy files when symlinks can be created but not read.
+
+    huggingface_hub only probes that a symlink can be *created*. On Windows a
+    link can be created yet not followed (SymlinkEvaluation policy, some AV or
+    sync tools), and opening a cached file then fails with
+    "[Errno 22] Invalid argument". Returns True when symlinks were disabled.
+    """
+    import os
+    import tempfile
+
+    from huggingface_hub import file_download
+
+    supported = getattr(file_download, "_are_symlinks_supported_in_dir", None)
+    if supported is None:
+        return False
+
+    with tempfile.TemporaryDirectory(dir=cache_dir) as tmp:
+        src = Path(tmp) / "src"
+        dst = Path(tmp) / "dst"
+        src.write_text("ok")
+        try:
+            os.symlink(os.path.relpath(src, tmp), dst)
+        except OSError:
+            return False  # cannot create links: huggingface_hub already copies
+        try:
+            readable = dst.read_text() == "ok"
+        except OSError:
+            readable = False
+
+    if readable:
+        return False
+    supported[str(cache_dir.expanduser().resolve())] = False
+    logger.warning(
+        "Symlinks in %s can be created but not read; huggingface_hub will copy model files instead",
+        cache_dir,
+    )
+    return True
 
 
 async def _run_shutdown() -> None:

--- a/backend/app.py
+++ b/backend/app.py
@@ -365,19 +365,17 @@ async def _run_startup(application: FastAPI) -> None:
 def disable_hf_symlinks_if_unreadable(cache_dir: Path) -> bool:
     """Make huggingface_hub copy files when symlinks can be created but not read.
 
-    huggingface_hub only probes that a symlink can be *created*. On Windows a
-    link can be created yet not followed (SymlinkEvaluation policy, some AV or
-    sync tools), and opening a cached file then fails with
-    "[Errno 22] Invalid argument". Returns True when symlinks were disabled.
+    huggingface_hub only probes that a symlink can be *created*. On some Windows
+    machines a link can be created yet not opened (security/filter drivers,
+    SymlinkEvaluation policy), and loading a cached model then fails with
+    "[Errno 22] Invalid argument" on the snapshot file. huggingface_hub checks
+    support per model directory, so override the check itself rather than its
+    per-directory cache. Returns True when symlinks were disabled.
     """
     import os
     import tempfile
 
     from huggingface_hub import file_download
-
-    supported = getattr(file_download, "_are_symlinks_supported_in_dir", None)
-    if supported is None:
-        return False
 
     with tempfile.TemporaryDirectory(dir=cache_dir) as tmp:
         src = Path(tmp) / "src"
@@ -394,7 +392,7 @@ def disable_hf_symlinks_if_unreadable(cache_dir: Path) -> bool:
 
     if readable:
         return False
-    supported[str(cache_dir.expanduser().resolve())] = False
+    file_download.are_symlinks_supported = lambda cache_dir=None: False
     logger.warning(
         "Symlinks in %s can be created but not read; huggingface_hub will copy model files instead",
         cache_dir,

--- a/backend/tests/test_hf_symlink_probe.py
+++ b/backend/tests/test_hf_symlink_probe.py
@@ -1,0 +1,41 @@
+"""The HF cache symlink probe must disable symlinks when links cannot be read."""
+
+from pathlib import Path
+
+import pytest
+from huggingface_hub import file_download
+
+from backend.app import disable_hf_symlinks_if_unreadable
+
+
+def _key(path: Path) -> str:
+    return str(path.expanduser().resolve())
+
+
+def test_readable_symlinks_leave_hf_alone(tmp_path):
+    before = dict(file_download._are_symlinks_supported_in_dir)
+    try:
+        assert disable_hf_symlinks_if_unreadable(tmp_path) is False
+        assert _key(tmp_path) not in file_download._are_symlinks_supported_in_dir
+    finally:
+        file_download._are_symlinks_supported_in_dir.clear()
+        file_download._are_symlinks_supported_in_dir.update(before)
+
+
+def test_unreadable_symlinks_disable_hf_symlinks(tmp_path, monkeypatch):
+    real_read_text = Path.read_text
+
+    def failing_read_text(self, *args, **kwargs):
+        if self.name == "dst":
+            raise OSError(22, "Invalid argument", str(self))
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", failing_read_text)
+    before = dict(file_download._are_symlinks_supported_in_dir)
+    try:
+        assert disable_hf_symlinks_if_unreadable(tmp_path) is True
+        assert file_download._are_symlinks_supported_in_dir[_key(tmp_path)] is False
+        assert file_download.are_symlinks_supported(tmp_path) is False
+    finally:
+        file_download._are_symlinks_supported_in_dir.clear()
+        file_download._are_symlinks_supported_in_dir.update(before)

--- a/backend/tests/test_hf_symlink_probe.py
+++ b/backend/tests/test_hf_symlink_probe.py
@@ -1,4 +1,4 @@
-"""The HF cache symlink probe must disable symlinks when links cannot be read."""
+"""The HF cache symlink probe must switch huggingface_hub to copy mode when links cannot be read."""
 
 from pathlib import Path
 
@@ -8,21 +8,19 @@ from huggingface_hub import file_download
 from backend.app import disable_hf_symlinks_if_unreadable
 
 
-def _key(path: Path) -> str:
-    return str(path.expanduser().resolve())
+@pytest.fixture
+def restore_hf(monkeypatch):
+    monkeypatch.setattr(file_download, "are_symlinks_supported", file_download.are_symlinks_supported)
+    yield
 
 
-def test_readable_symlinks_leave_hf_alone(tmp_path):
-    before = dict(file_download._are_symlinks_supported_in_dir)
-    try:
-        assert disable_hf_symlinks_if_unreadable(tmp_path) is False
-        assert _key(tmp_path) not in file_download._are_symlinks_supported_in_dir
-    finally:
-        file_download._are_symlinks_supported_in_dir.clear()
-        file_download._are_symlinks_supported_in_dir.update(before)
+def test_readable_symlinks_leave_hf_alone(tmp_path, restore_hf):
+    original = file_download.are_symlinks_supported
+    assert disable_hf_symlinks_if_unreadable(tmp_path) is False
+    assert file_download.are_symlinks_supported is original
 
 
-def test_unreadable_symlinks_disable_hf_symlinks(tmp_path, monkeypatch):
+def test_unreadable_symlinks_make_hf_copy_files(tmp_path, restore_hf, monkeypatch):
     real_read_text = Path.read_text
 
     def failing_read_text(self, *args, **kwargs):
@@ -31,11 +29,16 @@ def test_unreadable_symlinks_disable_hf_symlinks(tmp_path, monkeypatch):
         return real_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", failing_read_text)
-    before = dict(file_download._are_symlinks_supported_in_dir)
-    try:
-        assert disable_hf_symlinks_if_unreadable(tmp_path) is True
-        assert file_download._are_symlinks_supported_in_dir[_key(tmp_path)] is False
-        assert file_download.are_symlinks_supported(tmp_path) is False
-    finally:
-        file_download._are_symlinks_supported_in_dir.clear()
-        file_download._are_symlinks_supported_in_dir.update(before)
+    assert disable_hf_symlinks_if_unreadable(tmp_path) is True
+    # huggingface_hub consults this per model directory; it must say no everywhere now.
+    assert file_download.are_symlinks_supported(tmp_path / "models--x--y") is False
+
+    # And _create_symlink must then produce a real file, not a link.
+    blob = tmp_path / "blobs" / "abc"
+    blob.parent.mkdir()
+    blob.write_text("payload")
+    pointer = tmp_path / "snapshots" / "sha" / "config.yaml"
+    pointer.parent.mkdir(parents=True)
+    file_download._create_symlink(str(blob), str(pointer), new_blob=False)
+    assert pointer.is_file() and not pointer.is_symlink()
+    assert pointer.read_text() == "payload"


### PR DESCRIPTION
## Problem
Loading Habibi (F5-TTS) fails on one Windows machine with:

```
[Errno 22] Invalid argument: 'C:\Users\...\.cache\huggingface\hub\models--charactr--vocos-mel-24khz\snapshots\<sha>\config.yaml'
```

On that machine the download itself succeeds: `blobs/` holds both files with full sizes and `snapshots/<sha>/config.yaml` is a normal relative `<SYMLINK>` into `blobs/`. `fsutil behavior query SymlinkEvaluation` shows local-to-local ENABLED. The server process still cannot open through the link; CPython reports unmapped Win32 errors such as `ERROR_CANT_ACCESS_FILE` as `EINVAL`. huggingface_hub's `are_symlinks_supported` only verifies that a link can be *created*, so it keeps using links and every cached file stays unreadable.

## Fix
At startup, after creating the cache dir, create a temporary symlink and read through it. If creation succeeds but reading fails, replace `huggingface_hub.file_download.are_symlinks_supported` with a function returning False so `_create_symlink` copies files. huggingface_hub evaluates support per model directory (common path of blob and pointer), so overriding the function is the only switch that covers all repos. No behavior change where links work.

## Verification
- `test_hf_symlink_probe.py`: readable links leave huggingface_hub untouched; a simulated unreadable link flips the check and `_create_symlink` then writes a real file.
- End to end with a forced probe failure: `hf_hub_download("charactr/vocos-mel-24khz", "config.yaml")` produced a 461-byte regular file (not a link) and `Vocos.from_hparams` loaded it.

## Affected machine
Repo dirs already written as links (e.g. `models--charactr--vocos-mel-24khz`) must be deleted once so they are re-downloaded in copy mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)